### PR TITLE
Add dependabot, renovate, AGENTS.md, and CLAUDE.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+This repository welcomes contributions from AI agents.
+
+## Project Overview
+
+This is a Go API wrapper for the EODHD (End of Day Historical Data) financial API. The codebase provides HTTP client functionality with rate limiting, retry logic, and support for JSON/CSV response formats.
+
+## Repository Structure
+
+- `eodhd.go` — Core HTTP client implementation with rate limiting
+- `eodhd_options.go` — Client configuration options
+- `bulk_eod.go` — Bulk end-of-day data endpoint
+- `ohlcv.go` — OHLCV historical data endpoint
+- `tickers.go` — Ticker listing endpoint
+- `exchanges.go` — Exchange listing endpoint
+- `params.go` — Params interface
+- `util.go` — Utility helpers
+- `cmd/examples/` — Usage examples
+
+## Running Tests
+
+```bash
+go test ./...
+```
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Use GoDoc comments on all exported types and functions
+- Keep functions focused and small
+
+## Git Commits
+
+- One-line commit messages only (no body, no additional comments)
+- No attribution lines (no Co-Authored-By, no Signed-off-by)
+- Imperative mood (e.g., "add rate limiter", "fix validation bug")
+
+## Areas That Need Work
+
+- Test coverage is at 38% — many exported functions are untested
+- Most exported functions lack GoDoc comments
+- README is minimal and needs expansion
+- Input validation is missing in several places
+- There is a known bug in `ohlcv.go` where the `To` field has an incorrect URL tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This repository welcomes contributions from AI agents.
+
+## Project Overview
+
+This is a Go API wrapper for the EODHD (End of Day Historical Data) financial API. The codebase provides HTTP client functionality with rate limiting, retry logic, and support for JSON/CSV response formats.
+
+## Repository Structure
+
+- `eodhd.go` — Core HTTP client implementation with rate limiting
+- `eodhd_options.go` — Client configuration options
+- `bulk_eod.go` — Bulk end-of-day data endpoint
+- `ohlcv.go` — OHLCV historical data endpoint
+- `tickers.go` — Ticker listing endpoint
+- `exchanges.go` — Exchange listing endpoint
+- `params.go` — Params interface
+- `util.go` — Utility helpers
+- `cmd/examples/` — Usage examples
+
+## Running Tests
+
+```bash
+go test ./...
+```
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Use GoDoc comments on all exported types and functions
+- Keep functions focused and small
+
+## Git Commits
+
+- One-line commit messages only (no body, no additional comments)
+- No attribution lines (no Co-Authored-By, no Signed-off-by)
+- Imperative mood (e.g., "add rate limiter", "fix validation bug")
+
+## Areas That Need Work
+
+- Test coverage is at 38% — many exported functions are untested
+- Most exported functions lack GoDoc comments
+- README is minimal and needs expansion
+- Input validation is missing in several places
+- There is a known bug in `ohlcv.go` where the `To` field has an incorrect URL tag

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 5
+}


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for automated weekly Go module dependency updates
- Add `renovate.json` for Renovate bot dependency management
- Add `AGENTS.md` with project context for AI coding agents
- Add `CLAUDE.md` mirroring AGENTS.md with commit conventions (one-line, imperative, no attribution)

These files complement the license/contributing changes in PR #1 and are designed to attract autonomous AI agent contributions. 10 "good first issue" GitHub issues (#3–#12) have also been created.

## Test plan

- [x] `.github/dependabot.yml` configured for gomod with weekly schedule
- [x] `renovate.json` uses recommended config preset
- [x] `AGENTS.md` and `CLAUDE.md` contain matching project overview, structure, test commands, and commit guidelines

https://claude.ai/code/session_014GVXEcA6m5nxsuU9NhHSUz